### PR TITLE
Make it possible to specify custom scroll container

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Object describing the displacement from top of the viewport for the vertical scr
 Any other key, defined in number, will represent a different number of pixels or `rem` from top to which to stick,
 when the viewport width is less than the key.
 
+#### `scrollContainer`
+
+Reference to the app's scroll element, if not window.
+
 ## Release notes
 
 #### 1.7.0

--- a/src/StickyTableHeader.ts
+++ b/src/StickyTableHeader.ts
@@ -17,16 +17,19 @@ export default class StickyTableHeader {
   private lastElement: HTMLElement | null = null;
   private lastElementRefresh: number | null = null;
   private top: { max: number | string; [key: number]: number | string };
+  private scrollContainer?: HTMLElement;
 
   constructor(
     tableContainer: HTMLTableElement,
     cloneContainer: HTMLTableElement,
     top?: { max: number | string; [key: number]: number | string },
+    scrollContainer?: HTMLElement,
   ) {
     const header = tableContainer.querySelector<HTMLTableRowElement>('thead');
     this.tableContainer = tableContainer;
     this.cloneContainer = cloneContainer;
     this.top = top || {max: 0};
+    this.scrollContainer = scrollContainer;
 
     if (!header || !this.tableContainer.parentNode) {
       throw new Error('Header or parent node of sticky header table container not found!');
@@ -83,8 +86,9 @@ export default class StickyTableHeader {
       let containerRect = this.tableContainer.getBoundingClientRect();
       let cloneRect = this.cloneContainer.getBoundingClientRect();
       const bodyRect = document.body.getBoundingClientRect();
-      const currentScroll = window.scrollY;
-      window.scrollTo({ top: containerRect.y - bodyRect.y - this.getTop() - 60 });
+      const currentScroll = this.scrollContainer ? this.scrollContainer.scrollTop : window.scrollY;
+      const scrollElement = this.scrollContainer ?? window;
+      scrollElement.scrollTo({ top: containerRect.y - bodyRect.y - this.getTop() - 60 });
 
       containerRect = this.tableContainer.getBoundingClientRect();
       const originalTarget = document.elementFromPoint(
@@ -94,7 +98,7 @@ export default class StickyTableHeader {
       if (originalTarget && (originalTarget as HTMLElement).click) {
         (originalTarget as HTMLElement).click();
       }
-      window.scrollTo({top: currentScroll});
+      scrollElement.scrollTo({top: currentScroll});
     };
     this.cloneContainer.addEventListener('click', this.clickListener);
   }


### PR DESCRIPTION
I had some problems with the header elements not being clickable when in sticky mode (similar to #10?). Tracked it down to no original target being detected in `setupClickEventMirroring`. By allowing a custom reference to the app's scroll container I could solve it in my case.

Let me know if the fix is useful to others!