### PR TITLE
Support for multiple tbody tags

### DIFF
--- a/src/StickyTableHeader.js
+++ b/src/StickyTableHeader.js
@@ -251,7 +251,7 @@ var StickyTableHeader = /** @class */ (function () {
     StickyTableHeader.prototype.getLastElement = function () {
         var _this = this;
         if (!this.lastElement) {
-            this.lastElement = this.tableContainer.querySelector(':scope > tbody > tr:last-child');
+            this.lastElement = this.tableContainer.querySelector(':scope > tbody:last-of-type > tr:last-child');
             return this.lastElement;
         }
         if (this.lastElementRefresh) {

--- a/src/StickyTableHeader.ts
+++ b/src/StickyTableHeader.ts
@@ -296,7 +296,7 @@ export default class StickyTableHeader {
 
   private getLastElement() {
     if (!this.lastElement) {
-      this.lastElement = this.tableContainer.querySelector(':scope > tbody > tr:last-child');
+      this.lastElement = this.tableContainer.querySelector(':scope > tbody:last-of-type > tr:last-child');
       return this.lastElement;
     }
 


### PR DESCRIPTION
I ran into problems with using multi `tbody` elements for my use case - the header would stop being sticky as soon as the user reached the bottom of the first `tbody`.

Multiple `tbody` elements are accepted in the HTML standard, so long as they are consecutive: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#usage_notes