### PR TITLE
Support providing scrollContainer instead of parent tablecontainer by…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,15 @@ Options are provided to the constructor of the sticky table header instance.
 
 ```typescript
 export default class StickyTableHeader {
-  constructor(tableContainer: HTMLDivElement, cloneContainer: HTMLTableElement, top: {
-    max: number | string;
-    [key: number]: number | string;
-  });
+  constructor(
+    tableContainer: HTMLDivElement,
+    cloneContainer: HTMLTableElement,
+    top: {
+      max: number | string;
+      [key: number]: number | string;
+    },
+    scrollContainer: HTMLDivElement
+  )
 }
 ```
 
@@ -138,6 +143,11 @@ Object describing the displacement from top of the viewport for the vertical scr
 `max` is the default number of pixels or `rem` from top.
 Any other key, defined in number, will represent a different number of pixels or `rem` from top to which to stick,
 when the viewport width is less than the key.
+
+#### `scrollContainer`
+
+Object describing the scrolling element of the viewport for the vertical or horizontal scrolling. If not provided, the scrolling element is the parent element of tableContainer
+
 
 ## Release notes
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,12 @@ Options are provided to the constructor of the sticky table header instance.
 ```typescript
 export default class StickyTableHeader {
   constructor(
-    tableContainer: HTMLDivElement,
+    tableContainer: HTMLTableElement,
     cloneContainer: HTMLTableElement,
     top: {
       max: number | string;
       [key: number]: number | string;
-    },
-    scrollContainer: HTMLDivElement
+    }
   )
 }
 ```
@@ -143,11 +142,6 @@ Object describing the displacement from top of the viewport for the vertical scr
 `max` is the default number of pixels or `rem` from top.
 Any other key, defined in number, will represent a different number of pixels or `rem` from top to which to stick,
 when the viewport width is less than the key.
-
-#### `scrollContainer`
-
-Object describing the scrolling element of the viewport for the vertical or horizontal scrolling. If not provided, the scrolling element is the parent element of tableContainer
-
 
 ## Release notes
 

--- a/src/StickyTableHeader.ts
+++ b/src/StickyTableHeader.ts
@@ -7,7 +7,6 @@ export default class StickyTableHeader {
   private currentFrameRequest?: number;
   private containerScrollListener?: EventListener;
   private clickListener?: (event: MouseEvent) => any;
-  private tableContainerParent: HTMLDivElement;
   private tableContainer: HTMLTableElement;
   private cloneContainer: HTMLTableElement;
   private cloneContainerParent: HTMLDivElement;
@@ -17,11 +16,13 @@ export default class StickyTableHeader {
   private lastElement: HTMLElement | null = null;
   private lastElementRefresh: number | null = null;
   private top: { max: number | string; [key: number]: number | string };
+  private scrollContainer: HTMLDivElement;
 
   constructor(
     tableContainer: HTMLTableElement,
     cloneContainer: HTMLTableElement,
     top?: { max: number | string; [key: number]: number | string },
+    scrollContainer?: HTMLDivElement
   ) {
     const header = tableContainer.querySelector<HTMLTableRowElement>('thead');
     this.tableContainer = tableContainer;
@@ -32,7 +33,8 @@ export default class StickyTableHeader {
       throw new Error('Header or parent node of sticky header table container not found!');
     }
 
-    this.tableContainerParent = this.tableContainer.parentNode as HTMLDivElement;
+    this.scrollContainer = scrollContainer || this.tableContainer.parentNode as HTMLDivElement;
+
     this.cloneContainerParent = this.cloneContainer.parentNode as HTMLDivElement;
     this.header = header;
     this.scrollParents = this.getScrollParents(this.tableContainer);
@@ -75,7 +77,7 @@ export default class StickyTableHeader {
       window.removeEventListener('resize', this.sizeListener);
     }
     if (this.containerScrollListener) {
-      this.tableContainerParent.removeEventListener('click', this.containerScrollListener);
+      this.scrollContainer.removeEventListener('click', this.containerScrollListener);
     }
     if (this.clickListener) {
       this.cloneContainer.removeEventListener('click', this.clickListener);
@@ -223,7 +225,7 @@ export default class StickyTableHeader {
         this.setHorizontalScrollOnClone();
       });
     };
-    this.tableContainerParent.addEventListener('scroll', this.containerScrollListener);
+    this.scrollContainer.addEventListener('scroll', this.containerScrollListener);
   }
 
   private createClone(): HTMLTableRowElement {
@@ -252,8 +254,8 @@ export default class StickyTableHeader {
   }
 
   private setHorizontalScrollOnClone(): void {
-    this.cloneContainerParent.style.width = `${this.tableContainerParent.getBoundingClientRect().width}px`;
-    this.cloneContainerParent.scrollLeft = this.tableContainerParent.scrollLeft;
+    this.cloneContainerParent.style.width = `${this.scrollContainer.getBoundingClientRect().width}px`;
+    this.cloneContainerParent.scrollLeft = this.scrollContainer.scrollLeft;
   }
 
   private sizeToPx(size: number | string): number {

--- a/src/StickyTableHeader.ts
+++ b/src/StickyTableHeader.ts
@@ -16,13 +16,12 @@ export default class StickyTableHeader {
   private lastElement: HTMLElement | null = null;
   private lastElementRefresh: number | null = null;
   private top: { max: number | string; [key: number]: number | string };
-  private scrollContainer: HTMLDivElement;
+  private horizontalScrollContainer: HTMLElement;
 
   constructor(
     tableContainer: HTMLTableElement,
     cloneContainer: HTMLTableElement,
-    top?: { max: number | string; [key: number]: number | string },
-    scrollContainer?: HTMLDivElement
+    top?: { max: number | string; [key: number]: number | string }
   ) {
     const header = tableContainer.querySelector<HTMLTableRowElement>('thead');
     this.tableContainer = tableContainer;
@@ -33,22 +32,27 @@ export default class StickyTableHeader {
       throw new Error('Header or parent node of sticky header table container not found!');
     }
 
-    this.scrollContainer = scrollContainer || this.tableContainer.parentNode as HTMLDivElement;
-
     this.cloneContainerParent = this.cloneContainer.parentNode as HTMLDivElement;
     this.header = header;
-    this.scrollParents = this.getScrollParents(this.tableContainer);
+    this.scrollParents = this.getScrollParents(this.tableContainer, 'vertical');
+    this.horizontalScrollContainer = this.getScrollParents(this.tableContainer, 'horizontal')[0] || this.tableContainer.parentNode;
 
     this.setup();
   }
 
-  private getScrollParents(node: HTMLElement): HTMLElement[] {
+  private getScrollParents(node: HTMLElement, direction: 'horizontal' | 'vertical'): HTMLElement[] {
     const parents: HTMLElement[] = [];
     let parent: any = node.parentNode;
 
     while (parent) {
-      if (parent.scrollHeight > parent.clientHeight && parent !== window) {
-        parents.push(parent);
+      if (direction === 'vertical') {
+        if (parent.scrollHeight > parent.clientHeight && parent !== window) {
+          parents.push(parent);
+        }
+      } else {
+        if (parent.scrollWidth > parent.clientWidth && parent !== window) {
+          parents.push(parent);
+        }
       }
       parent = parent.parentNode as HTMLElement | null;
     }
@@ -77,7 +81,7 @@ export default class StickyTableHeader {
       window.removeEventListener('resize', this.sizeListener);
     }
     if (this.containerScrollListener) {
-      this.scrollContainer.removeEventListener('click', this.containerScrollListener);
+      this.horizontalScrollContainer.removeEventListener('scroll', this.containerScrollListener);
     }
     if (this.clickListener) {
       this.cloneContainer.removeEventListener('click', this.clickListener);
@@ -225,7 +229,7 @@ export default class StickyTableHeader {
         this.setHorizontalScrollOnClone();
       });
     };
-    this.scrollContainer.addEventListener('scroll', this.containerScrollListener);
+    this.horizontalScrollContainer.addEventListener('scroll', this.containerScrollListener);
   }
 
   private createClone(): HTMLTableRowElement {
@@ -254,8 +258,8 @@ export default class StickyTableHeader {
   }
 
   private setHorizontalScrollOnClone(): void {
-    this.cloneContainerParent.style.width = `${this.scrollContainer.getBoundingClientRect().width}px`;
-    this.cloneContainerParent.scrollLeft = this.scrollContainer.scrollLeft;
+    this.cloneContainerParent.style.width = `${this.horizontalScrollContainer.getBoundingClientRect().width}px`;
+    this.cloneContainerParent.scrollLeft = this.horizontalScrollContainer.scrollLeft;
   }
 
   private sizeToPx(size: number | string): number {

--- a/test/test_horizontal_scroll.html
+++ b/test/test_horizontal_scroll.html
@@ -1,0 +1,775 @@
+<!DOCTYPE html>
+<html lang="">
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="module">
+        import { StickyTableHeader } from '../build/esm/index.js'
+
+        document.body.onload = () => {
+            const table = document.getElementById('table');
+            const clone = document.getElementById('clone');
+
+            new StickyTableHeader(
+                table,
+                clone,
+                { max: 60 }
+            )
+        };
+    </script>
+</head>
+
+<body>
+    <style>
+        body {
+            font-family: arial;
+            margin: 0;
+            margin-bottom: 1500px;
+        }
+
+        #root {
+            padding-top: 60px;
+            padding-left: 20px;
+            padding-right: 20px;
+        }
+
+        .margin {
+            padding-bottom: 150px;
+        }
+
+        th,
+        td {
+            padding: 15px;
+            text-align: left;
+        }
+
+        table {
+            border-spacing: 0;
+            overflow-x: scroll;
+            min-width: 100%;
+            width: 100%;
+        }
+
+        .thead th {
+            background: #f4f1ed;
+        }
+
+        .header {
+            width: 100%;
+            height: 60px;
+            position: fixed;
+            top: 0;
+            left: 0;
+            background: grey;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: wheat;
+            z-index: 10;
+        }
+
+        .table_container {
+            display: grid;
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: hidden;
+            border-radius: 15px;
+            box-shadow: 1px 1px 15px rgba(0, 0, 0, 0.2);
+        }
+
+        .clone_table {
+            box-shadow: 0 5px 3px -3px rgba(0, 0, 0, 0.25);
+            border-radius: 0;
+        }
+
+        .text {
+            white-space: nowrap;
+        }
+
+        .maxcontent {
+            min-width: max-content;
+        }
+
+        .content {
+            display: grid;
+            grid-auto-flow: column;
+            align-items: stretch;
+        }
+    </style>
+
+    <div id="root">
+        <div class="header">
+            <div>Header</div>
+        </div>
+        <div class="margin">
+            <p>1. Scroll down to see table header stick.</p>
+            <p>2. Make the viewport width smaller, so that columns don't fit anymore. A scroll bar will appear on bottom
+                of
+                table to scroll horizontally. Observe sticky header scrolling as well.</p>
+        </div>
+        <div class="table_container">
+            <div class="maxcontent">
+                <div class="content">
+                    <p class="text"> ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, sapien nec
+                        tincidunt tincidunt, nulla justo vehicula magna, nec fermentum sapien erat nec erat. Suspendisse
+                        potenti. Curabitur ac orci vitae sapien tincidunt tincidunt. Fusce nec justo vel justo tincidunt
+                        tincidunt. Integer nec sapien nec sapien tincidunt tincidunt. Sed nec sapien nec sapien
+                        tincidunt tincidunt.
+                    </p>
+                </div>
+                <table id="table">
+                    <thead>
+                        <tr class="thead">
+                            <th>Id <input type="checkbox" name="test" /></th>
+                            <th>Name</th>
+                            <th>Role</th>
+                            <th>City</th>
+                            <th>Age</th>
+                            <th>Start date</th>
+                            <th>Salary</th>
+                            <th>Status</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>0</td>
+                            <td>t
+                            </td>
+                            <td>System Architect</td>
+                            <td>Edinburgh</td>
+                            <td>61</td>
+                            <td>2011/04/25</td>
+                            <td>$320,800</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>1</td>
+                            <td>Garrett Winters</td>
+                            <td>Accountant</td>
+                            <td>Tokyo</td>
+                            <td>63</td>
+                            <td>2011/07/25</td>
+                            <td>$170,750</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>Ashton Cox</td>
+                            <td>Junior Technical Author</td>
+                            <td>San Francisco</td>
+                            <td>66</td>
+                            <td>2009/01/12</td>
+                            <td>$86,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>3</td>
+                            <td>Cedric Kelly</td>
+                            <td>Senior Javascript Developer</td>
+                            <td>Edinburgh</td>
+                            <td>22</td>
+                            <td>2012/03/29</td>
+                            <td>$433,060</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>4</td>
+                            <td>Airi Satou</td>
+                            <td>Accountant</td>
+                            <td>Tokyo</td>
+                            <td>33</td>
+                            <td>2008/11/28</td>
+                            <td>$162,700</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>5</td>
+                            <td>Brielle Williamson</td>
+                            <td>Integration Specialist</td>
+                            <td>New York</td>
+                            <td>61</td>
+                            <td>2012/12/02</td>
+                            <td>$372,000</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>6</td>
+                            <td>Herrod Chandler</td>
+                            <td>Sales Assistant</td>
+                            <td>San Francisco</td>
+                            <td>59</td>
+                            <td>2012/08/06</td>
+                            <td>$137,500</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>7</td>
+                            <td>Rhona Davidson</td>
+                            <td>Integration Specialist</td>
+                            <td>Tokyo</td>
+                            <td>55</td>
+                            <td>2010/10/14</td>
+                            <td>$327,900</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>8</td>
+                            <td>Colleen Hurst</td>
+                            <td>Javascript Developer</td>
+                            <td>San Francisco</td>
+                            <td>39</td>
+                            <td>2009/09/15</td>
+                            <td>$205,500</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>9</td>
+                            <td>Sonya Frost</td>
+                            <td>Software Engineer</td>
+                            <td>Edinburgh</td>
+                            <td>23</td>
+                            <td>2008/12/13</td>
+                            <td>$103,600</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>10</td>
+                            <td>Jena Gaines</td>
+                            <td>Office Manager</td>
+                            <td>London</td>
+                            <td>30</td>
+                            <td>2008/12/19</td>
+                            <td>$90,560</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>11</td>
+                            <td>Quinn Flynn</td>
+                            <td>Support Lead</td>
+                            <td>Edinburgh</td>
+                            <td>22</td>
+                            <td>2013/03/03</td>
+                            <td>$342,000</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>12</td>
+                            <td>Charde Marshall</td>
+                            <td>Regional Director</td>
+                            <td>San Francisco</td>
+                            <td>36</td>
+                            <td>2008/10/16</td>
+                            <td>$470,600</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>13</td>
+                            <td>Haley Kennedy</td>
+                            <td>Senior Marketing Designer</td>
+                            <td>London</td>
+                            <td>43</td>
+                            <td>2012/12/18</td>
+                            <td>$313,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>14</td>
+                            <td>Tatyana Fitzpatrick</td>
+                            <td>Regional Director</td>
+                            <td>London</td>
+                            <td>19</td>
+                            <td>2010/03/17</td>
+                            <td>$385,750</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>15</td>
+                            <td>Michael Silva</td>
+                            <td>Marketing Designer</td>
+                            <td>London</td>
+                            <td>66</td>
+                            <td>2012/11/27</td>
+                            <td>$198,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>16</td>
+                            <td>Paul Byrd</td>
+                            <td>Chief Financial Officer (CFO)</td>
+                            <td>New York</td>
+                            <td>64</td>
+                            <td>2010/06/09</td>
+                            <td>$725,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>17</td>
+                            <td>Gloria Little</td>
+                            <td>Systems Administrator</td>
+                            <td>New York</td>
+                            <td>59</td>
+                            <td>2009/04/10</td>
+                            <td>$237,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>18</td>
+                            <td>Bradley Greer</td>
+                            <td>Software Engineer</td>
+                            <td>London</td>
+                            <td>41</td>
+                            <td>2012/10/13</td>
+                            <td>$132,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>19</td>
+                            <td>Dai Rios</td>
+                            <td>Personnel Lead</td>
+                            <td>Edinburgh</td>
+                            <td>35</td>
+                            <td>2012/09/26</td>
+                            <td>$217,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>20</td>
+                            <td>Jenette Caldwell</td>
+                            <td>Development Lead</td>
+                            <td>New York</td>
+                            <td>30</td>
+                            <td>2011/09/03</td>
+                            <td>$345,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>21</td>
+                            <td>Yuri Berry</td>
+                            <td>Chief Marketing Officer (CMO)</td>
+                            <td>New York</td>
+                            <td>40</td>
+                            <td>2009/06/25</td>
+                            <td>$675,000</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>22</td>
+                            <td>Caesar Vance</td>
+                            <td>Pre-Sales Support</td>
+                            <td>New York</td>
+                            <td>21</td>
+                            <td>2011/12/12</td>
+                            <td>$106,450</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>23</td>
+                            <td>Doris Wilder</td>
+                            <td>Sales Assistant</td>
+                            <td>Sidney</td>
+                            <td>23</td>
+                            <td>2010/09/20</td>
+                            <td>$85,600</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>24</td>
+                            <td>Angelica Ramos</td>
+                            <td>Chief Executive Officer (CEO)</td>
+                            <td>London</td>
+                            <td>47</td>
+                            <td>2009/10/09</td>
+                            <td>$1,200,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>25</td>
+                            <td>Gavin Joyce</td>
+                            <td>Developer</td>
+                            <td>Edinburgh</td>
+                            <td>42</td>
+                            <td>2010/12/22</td>
+                            <td>$92,575</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>26</td>
+                            <td>Jennifer Chang</td>
+                            <td>Regional Director</td>
+                            <td>Singapore</td>
+                            <td>28</td>
+                            <td>2010/11/14</td>
+                            <td>$357,650</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>27</td>
+                            <td>Brenden Wagner</td>
+                            <td>Software Engineer</td>
+                            <td>San Francisco</td>
+                            <td>28</td>
+                            <td>2011/06/07</td>
+                            <td>$206,850</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>28</td>
+                            <td>Fiona Green</td>
+                            <td>Chief Operating Officer (COO)</td>
+                            <td>San Francisco</td>
+                            <td>48</td>
+                            <td>2010/03/11</td>
+                            <td>$850,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>29</td>
+                            <td>Shou Itou</td>
+                            <td>Regional Marketing</td>
+                            <td>Tokyo</td>
+                            <td>20</td>
+                            <td>2011/08/14</td>
+                            <td>$163,000</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>30</td>
+                            <td>Michelle House</td>
+                            <td>Integration Specialist</td>
+                            <td>Sidney</td>
+                            <td>37</td>
+                            <td>2011/06/02</td>
+                            <td>$95,400</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>31</td>
+                            <td>Suki Burks</td>
+                            <td>Developer</td>
+                            <td>London</td>
+                            <td>53</td>
+                            <td>2009/10/22</td>
+                            <td>$114,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>32</td>
+                            <td>Prescott Bartlett</td>
+                            <td>Technical Author</td>
+                            <td>London</td>
+                            <td>27</td>
+                            <td>2011/05/07</td>
+                            <td>$145,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>33</td>
+                            <td>Gavin Cortez</td>
+                            <td>Team Leader</td>
+                            <td>San Francisco</td>
+                            <td>22</td>
+                            <td>2008/10/26</td>
+                            <td>$235,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>34</td>
+                            <td>Martena Mccray</td>
+                            <td>Post-Sales support</td>
+                            <td>Edinburgh</td>
+                            <td>46</td>
+                            <td>2011/03/09</td>
+                            <td>$324,050</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>35</td>
+                            <td>Unity Butler</td>
+                            <td>Marketing Designer</td>
+                            <td>San Francisco</td>
+                            <td>47</td>
+                            <td>2009/12/09</td>
+                            <td>$85,675</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>36</td>
+                            <td>Howard Hatfield</td>
+                            <td>Office Manager</td>
+                            <td>San Francisco</td>
+                            <td>51</td>
+                            <td>2008/12/16</td>
+                            <td>$164,500</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>37</td>
+                            <td>Hope Fuentes</td>
+                            <td>Secretary</td>
+                            <td>San Francisco</td>
+                            <td>41</td>
+                            <td>2010/02/12</td>
+                            <td>$109,850</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>38</td>
+                            <td>Vivian Harrell</td>
+                            <td>Financial Controller</td>
+                            <td>San Francisco</td>
+                            <td>62</td>
+                            <td>2009/02/14</td>
+                            <td>$452,500</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>39</td>
+                            <td>Timothy Mooney</td>
+                            <td>Office Manager</td>
+                            <td>London</td>
+                            <td>37</td>
+                            <td>2008/12/11</td>
+                            <td>$136,200</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>40</td>
+                            <td>Jackson Bradshaw</td>
+                            <td>Director</td>
+                            <td>New York</td>
+                            <td>65</td>
+                            <td>2008/09/26</td>
+                            <td>$645,750</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>41</td>
+                            <td>Olivia Liang</td>
+                            <td>Support Engineer</td>
+                            <td>Singapore</td>
+                            <td>64</td>
+                            <td>2011/02/03</td>
+                            <td>$234,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>42</td>
+                            <td>Bruno Nash</td>
+                            <td>Software Engineer</td>
+                            <td>London</td>
+                            <td>38</td>
+                            <td>2011/05/03</td>
+                            <td>$163,500</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>43</td>
+                            <td>Sakura Yamamoto</td>
+                            <td>Support Engineer</td>
+                            <td>Tokyo</td>
+                            <td>37</td>
+                            <td>2009/08/19</td>
+                            <td>$139,575</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>44</td>
+                            <td>Thor Walton</td>
+                            <td>Developer</td>
+                            <td>New York</td>
+                            <td>61</td>
+                            <td>2013/08/11</td>
+                            <td>$98,540</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>45</td>
+                            <td>Finn Camacho</td>
+                            <td>Support Engineer</td>
+                            <td>San Francisco</td>
+                            <td>47</td>
+                            <td>2009/07/07</td>
+                            <td>$87,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>46</td>
+                            <td>Serge Baldwin</td>
+                            <td>Data Coordinator</td>
+                            <td>Singapore</td>
+                            <td>64</td>
+                            <td>2012/04/09</td>
+                            <td>$138,575</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>47</td>
+                            <td>Zenaida Frank</td>
+                            <td>Software Engineer</td>
+                            <td>New York</td>
+                            <td>63</td>
+                            <td>2010/01/04</td>
+                            <td>$125,250</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>48</td>
+                            <td>Zorita Serrano</td>
+                            <td>Software Engineer</td>
+                            <td>San Francisco</td>
+                            <td>56</td>
+                            <td>2012/06/01</td>
+                            <td>$115,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>49</td>
+                            <td>Jennifer Acosta</td>
+                            <td>Junior Javascript Developer</td>
+                            <td>Edinburgh</td>
+                            <td>43</td>
+                            <td>2013/02/01</td>
+                            <td>$75,650</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>50</td>
+                            <td>Cara Stevens</td>
+                            <td>Sales Assistant</td>
+                            <td>New York</td>
+                            <td>46</td>
+                            <td>2011/12/06</td>
+                            <td>$145,600</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                    </tbody>
+                    <tbody>
+                        <tr>
+                            <td>51</td>
+                            <td>Hermione Butler</td>
+                            <td>Regional Director</td>
+                            <td>London</td>
+                            <td>47</td>
+                            <td>2011/03/21</td>
+                            <td>$356,250</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>52</td>
+                            <td>Lael Greer</td>
+                            <td>Systems Administrator</td>
+                            <td>London</td>
+                            <td>21</td>
+                            <td>2009/02/27</td>
+                            <td>$103,500</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>53</td>
+                            <td>Jonas Alexander</td>
+                            <td>Developer</td>
+                            <td>San Francisco</td>
+                            <td>30</td>
+                            <td>2010/07/14</td>
+                            <td>$86,500</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>54</td>
+                            <td>Shad Decker</td>
+                            <td>Regional Director</td>
+                            <td>Edinburgh</td>
+                            <td>51</td>
+                            <td>2008/11/13</td>
+                            <td>$183,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>55</td>
+                            <td>Michael Bruce</td>
+                            <td>Javascript Developer</td>
+                            <td>Singapore</td>
+                            <td>29</td>
+                            <td>2011/06/27</td>
+                            <td>$183,000</td>
+                            <td>on</td>
+                            <td>Edit</td>
+                        </tr>
+                        <tr>
+                            <td>56</td>
+                            <td>Donna Snider</td>
+                            <td>Customer Support</td>
+                            <td>New York</td>
+                            <td>27</td>
+                            <td>2011/01/25</td>
+                            <td>$112,000</td>
+                            <td>off</td>
+                            <td>Edit</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="clone_table table_container">
+                <table id="clone"></table>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
I ran an issue where the sticky header of my table did not scroll. It is because the scroll element is not the parent of table container.

i don't want to have the scroll container defined on the parent element of table container.

I think it could be useful for anyone to specify if they want the scroll container especially for horizontal of vertical scroll when scroll element is not the parent element

With this solution i resolved my issue